### PR TITLE
Persist S3 upload status cache across runs

### DIFF
--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -20,6 +20,12 @@ from pwnagotchi.utils import StatusFile
 from json import JSONDecodeError
 from flask import abort, render_template_string, Response, url_for
 
+try:
+    from flask_wtf.csrf import generate_csrf
+except ImportError:  # pragma: no cover - fallback when csrf extension unavailable
+    def generate_csrf():
+        return ''
+
 # Try to import boto3, install if not available
 try:
     import boto3
@@ -35,99 +41,206 @@ WEB_STATUS_TEMPLATE = """
 {% set active_page = "plugins" %}
 {% block title %}S3 Upload Status{% endblock %}
 
+{% block styles %}
+{{ super() }}
+<style>
+  .s3-status .status-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  .s3-status .status-chip {
+    background: rgba(236, 239, 241, 0.6);
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    line-height: 1.4;
+  }
+
+  .s3-status .status-chip .label {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: #607d8b;
+    display: block;
+    margin-bottom: 0.35rem;
+  }
+
+  .s3-status .status-chip .value {
+    font-weight: 600;
+    word-break: break-word;
+  }
+
+  .s3-status .table-wrapper {
+    overflow-x: auto;
+  }
+
+  .s3-status table {
+    min-width: 680px;
+  }
+
+  .s3-status td code {
+    word-break: break-all;
+  }
+
+  .s3-status .truncate {
+    display: inline-block;
+    max-width: 100%;
+  }
+
+  @media (max-width: 720px) {
+    .s3-status .table-wrapper {
+      overflow-x: visible;
+    }
+
+    .s3-status table,
+    .s3-status thead,
+    .s3-status tbody,
+    .s3-status th,
+    .s3-status td,
+    .s3-status tr {
+      display: block;
+    }
+
+    .s3-status thead tr {
+      display: none;
+    }
+
+    .s3-status tr {
+      margin-bottom: 1.2rem;
+      border: 1px solid rgba(176, 190, 197, 0.6);
+      border-radius: 6px;
+      padding: 0.75rem;
+    }
+
+    .s3-status td {
+      border: none;
+      position: relative;
+      padding-left: 45%;
+      min-height: 2rem;
+    }
+
+    .s3-status td::before {
+      content: attr(data-label);
+      position: absolute;
+      left: 0.75rem;
+      width: 40%;
+      font-weight: 600;
+      color: #546e7a;
+      text-transform: uppercase;
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+    }
+
+    .s3-status td[data-label="Actions"] {
+      padding-left: 1rem;
+    }
+
+    .s3-status td[data-label="Actions"]::before {
+      display: none;
+    }
+
+    .s3-status form {
+      text-align: right;
+    }
+  }
+</style>
+{% endblock %}
+
 {% block content %}
-{% if feedback %}
-<div class="card-panel {{ 'green lighten-5' if feedback.category == 'success' else 'red lighten-5' }}">
-  <span class="{{ 'green-text text-darken-4' if feedback.category == 'success' else 'red-text text-darken-4' }}">{{ feedback.message }}</span>
-</div>
-{% endif %}
-
-<div class="card">
-  <div class="card-content">
-    <span class="card-title">Status Overview</span>
-    <table class="striped">
-      <tbody>
-        <tr>
-          <th scope="row">Status file</th>
-          <td>{{ status_path }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Exists</th>
-          <td>{{ 'Yes' if status_exists else 'No' }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Last updated</th>
-          <td>{{ status_mtime or 'Never' }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Total uploaded (unique)</th>
-          <td>{{ status_summary.total_uploaded }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Last upload</th>
-          <td>{{ status_summary.last_upload }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Total handshakes found</th>
-          <td>{{ status_summary.total_handshakes }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Pending uploads</th>
-          <td>{{ status_summary.pending_count }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Tracked records</th>
-          <td>{{ uploaded_records|length }}</td>
-        </tr>
-      </tbody>
-    </table>
+<div class="s3-status">
+  {% if feedback %}
+  <div class="card-panel {{ 'green lighten-5' if feedback.category == 'success' else 'red lighten-5' }}">
+    <span class="{{ 'green-text text-darken-4' if feedback.category == 'success' else 'red-text text-darken-4' }}">{{ feedback.message }}</span>
   </div>
-  <div class="card-action">
-    <a href="{{ status_download_url }}" class="btn" download>Download status JSON</a>
-  </div>
-</div>
+  {% endif %}
 
-<div class="card">
-  <div class="card-content">
-    <span class="card-title">Tracked Uploads</span>
-    {% if uploaded_records %}
-    <div class="table-responsive">
-      <table class="striped responsive-table">
-        <thead>
-          <tr>
-            <th>File</th>
-            <th>Checksum</th>
-            <th>Size</th>
-            <th>Uploaded</th>
-            <th>Last Updated</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for record in uploaded_records %}
-          <tr>
-            <td>{{ record.display_path }}</td>
-            <td><code>{{ record.display_checksum }}</code></td>
-            <td>{{ record.display_size }}</td>
-            <td>{{ record.uploaded_at }}</td>
-            <td>{{ record.updated_at }}</td>
-            <td>
-              <form method="post" action="{{ page_url }}" style="display:inline">
-                <input type="hidden" name="action" value="clear">
-                <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
-                <button type="submit" class="btn-flat waves-effect red-text text-accent-4" title="Remove this record">
-                  Clear
-                </button>
-              </form>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+  <div class="card">
+    <div class="card-content">
+      <span class="card-title">Status Overview</span>
+      <div class="status-meta">
+        <div class="status-chip">
+          <span class="label">Status file</span>
+          <span class="value">{{ status_path }}</span>
+        </div>
+        <div class="status-chip">
+          <span class="label">Exists</span>
+          <span class="value">{{ 'Yes' if status_exists else 'No' }}</span>
+        </div>
+        <div class="status-chip">
+          <span class="label">Last updated</span>
+          <span class="value">{{ status_mtime or 'Never' }}</span>
+        </div>
+        <div class="status-chip">
+          <span class="label">Total uploaded (unique)</span>
+          <span class="value">{{ status_summary.total_uploaded }}</span>
+        </div>
+        <div class="status-chip">
+          <span class="label">Last upload</span>
+          <span class="value">{{ status_summary.last_upload }}</span>
+        </div>
+        <div class="status-chip">
+          <span class="label">Total handshakes found</span>
+          <span class="value">{{ status_summary.total_handshakes }}</span>
+        </div>
+        <div class="status-chip">
+          <span class="label">Pending uploads</span>
+          <span class="value">{{ status_summary.pending_count }}</span>
+        </div>
+        <div class="status-chip">
+          <span class="label">Tracked records</span>
+          <span class="value">{{ uploaded_records|length }}</span>
+        </div>
+      </div>
     </div>
-    {% else %}
-    <p>No upload records available.</p>
-    {% endif %}
+    <div class="card-action">
+      <a href="{{ status_download_url }}" class="btn" download>Download status JSON</a>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-content">
+      <span class="card-title">Tracked Uploads</span>
+      {% if uploaded_records %}
+      <div class="table-wrapper">
+        <table class="striped highlight">
+          <thead>
+            <tr>
+              <th scope="col">File</th>
+              <th scope="col">Checksum</th>
+              <th scope="col">Size</th>
+              <th scope="col">Uploaded</th>
+              <th scope="col">Last Updated</th>
+              <th scope="col" class="right-align">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for record in uploaded_records %}
+            <tr>
+              <td data-label="File"><span class="truncate">{{ record.display_path }}</span></td>
+              <td data-label="Checksum"><code>{{ record.display_checksum }}</code></td>
+              <td data-label="Size">{{ record.display_size }}</td>
+              <td data-label="Uploaded">{{ record.uploaded_at }}</td>
+              <td data-label="Last Updated">{{ record.updated_at }}</td>
+              <td data-label="Actions" class="right-align">
+                <form method="post" action="{{ page_url }}" class="inline-form">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <input type="hidden" name="action" value="clear">
+                  <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
+                  <button type="submit" class="btn-flat waves-effect red-text text-accent-4" title="Remove this record">
+                    Clear
+                  </button>
+                </form>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="grey-text text-darken-1">No upload records available.</p>
+      {% endif %}
+    </div>
   </div>
 </div>
 {% endblock %}
@@ -972,7 +1085,8 @@ class PwnS3Upload(plugins.Plugin):
                 uploaded_records=display_records,
                 status_download_url=status_download_url,
                 page_url=page_url,
-                feedback=feedback
+                feedback=feedback,
+                csrf_token=generate_csrf
             )
 
         if normalized_path == 'status.json':

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -44,267 +44,110 @@ WEB_STATUS_TEMPLATE = """
 {% block styles %}
 {{ super() }}
 <style>
-  .s3-status {
-    --s3-surface: #ffffff;
-    --s3-border: rgba(176, 190, 197, 0.55);
-    --s3-muted: #455a64;
-    --s3-heading: #263238;
-    --s3-chip: rgba(236, 239, 241, 0.55);
-    --s3-chip-border: rgba(120, 144, 156, 0.22);
-  }
-
   .s3-status .card {
     margin-bottom: 2rem;
-    border-radius: 18px;
-    border: 1px solid var(--s3-border);
-    box-shadow: 0 14px 28px rgba(38, 50, 56, 0.08);
-    background: var(--s3-surface);
-  }
-
-  .s3-status .card-content {
-    padding: 2rem;
   }
 
   .s3-status .card-title {
-    margin: 0 0 1.5rem;
-    font-weight: 600;
-    color: var(--s3-heading);
-    font-size: 1.55rem;
-    line-height: 1.3;
-    letter-spacing: -0.01em;
+    font-size: 1.6rem;
+    margin-bottom: 1.5rem;
   }
 
-  .s3-status .section-block {
-    border-radius: 14px;
-    border: 1px solid var(--s3-border);
-    background: rgba(236, 239, 241, 0.4);
-    padding: 1.35rem 1.5rem;
-    margin-top: 1.5rem;
-  }
-
-  .s3-status .section-block:first-of-type {
-    margin-top: 0;
-  }
-
-  .s3-status .section-heading {
-    margin: 0 0 0.85rem;
-    font-size: 0.92rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--s3-muted);
-  }
-
-  .s3-status .section-text {
-    margin: 0 0 1rem;
-    color: #37474f;
-    font-size: 0.95rem;
-    line-height: 1.5;
-  }
-
-  .s3-status .status-meta {
+  .s3-status .stat-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 1rem;
+    margin-bottom: 1.5rem;
   }
 
-  .s3-status .status-chip {
-    background: var(--s3-chip);
-    border-radius: 12px;
-    padding: 0.9rem 1.1rem;
-    line-height: 1.45;
-    box-shadow: inset 0 0 0 1px var(--s3-chip-border);
-  }
-
-  .s3-status .status-chip .label {
-    text-transform: uppercase;
-    font-size: 0.7rem;
-    letter-spacing: 0.08em;
-    color: #546e7a;
-    display: block;
-    margin-bottom: 0.35rem;
-  }
-
-  .s3-status .status-chip .value {
-    font-weight: 600;
-    font-size: 0.95rem;
-    word-break: break-word;
-    color: var(--s3-heading);
-  }
-
-  .s3-status .download-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    color: #1a237e;
-    text-decoration: none;
-    font-weight: 600;
-    padding: 0.45rem 0.85rem;
+  .s3-status .stat {
+    border: 1px solid #e0e0e0;
     border-radius: 8px;
-    transition: background 150ms ease, color 150ms ease;
-  }
-
-  .s3-status .download-link:hover,
-  .s3-status .download-link:focus {
-    background: rgba(26, 35, 126, 0.12);
-    color: #0d47a1;
-  }
-
-  .s3-status .download-link .material-icons {
-    font-size: 1.1rem;
-  }
-
-  .s3-status .table-wrapper {
-    margin-top: 0.5rem;
-    overflow-x: auto;
-    border-radius: 12px;
-    border: 1px solid rgba(176, 190, 197, 0.6);
-    background: #fff;
-  }
-
-  .s3-status table {
-    margin-bottom: 0;
-    width: 100%;
-    min-width: 640px;
-    border-collapse: collapse;
-  }
-
-  .s3-status table thead th {
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.72rem;
-    color: var(--s3-muted);
-    background-color: rgba(236, 239, 241, 0.8);
-    border-bottom: 1px solid rgba(120, 144, 156, 0.3);
-  }
-
-  .s3-status table td,
-  .s3-status table th {
+    background: #fafafa;
     padding: 0.85rem 1rem;
   }
 
-  .s3-status table tbody tr:nth-child(even) {
-    background-color: rgba(236, 239, 241, 0.35);
+  .s3-status .stat .label {
+    display: block;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #546e7a;
+    margin-bottom: 0.25rem;
   }
 
-  .s3-status table tbody tr:hover {
-    background-color: rgba(207, 216, 220, 0.35);
-  }
-
-  .s3-status table tbody td {
-    font-size: 0.9rem;
-    color: #37474f;
-  }
-
-  .s3-status td code,
-  .s3-status td .mono {
-    word-break: break-all;
-    font-family: "Roboto Mono", "Source Code Pro", monospace;
-    font-size: 0.85rem;
-    color: var(--s3-heading);
+  .s3-status .stat .value {
+    font-weight: 600;
+    color: #263238;
+    word-break: break-word;
   }
 
   .s3-status .mono {
     font-family: "Roboto Mono", "Source Code Pro", monospace;
   }
 
-  .s3-status td code {
-    background-color: rgba(207, 216, 220, 0.35);
-    padding: 0.2rem 0.35rem;
-    border-radius: 4px;
-    display: inline-block;
+  .s3-status .download-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .s3-status .table-wrapper {
+    overflow-x: auto;
+  }
+
+  .s3-status table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .s3-status thead th {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.75rem;
+    color: #546e7a;
+    background: #eceff1;
+  }
+
+  .s3-status th,
+  .s3-status td {
+    padding: 0.75rem 0.9rem;
+  }
+
+  .s3-status tbody tr:nth-child(even) {
+    background: #f7f9fa;
+  }
+
+  .s3-status tbody td {
+    color: #37474f;
+    font-size: 0.9rem;
   }
 
   .s3-status .truncate {
-    display: inline-flex;
-    align-items: center;
+    display: inline-block;
     max-width: 100%;
-  }
-
-  .s3-status .inline-form {
-    display: inline-flex;
-    align-items: center;
-  }
-
-  .s3-status .inline-form .action-btn {
-    width: 42px;
-    height: 42px;
-    border-radius: 10px;
-    border: none;
-    background: #d32f2f;
-    color: #fff;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
-    cursor: pointer;
-  }
-
-  .s3-status .inline-form .action-btn .material-icons {
-    font-size: 1.15rem;
-  }
-
-  .s3-status .inline-form .action-btn:hover,
-  .s3-status .inline-form .action-btn:focus {
-    background: #b71c1c;
-    box-shadow: 0 4px 12px rgba(183, 28, 28, 0.35);
-    transform: translateY(-1px);
-  }
-
-  .s3-status .inline-form .action-btn:focus-visible {
-    outline: 2px solid #ffcdd2;
-    outline-offset: 2px;
-  }
-
-  .s3-status th.right-align,
-  .s3-status td.right-align {
-    text-align: right;
-  }
-
-  .s3-status .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
+    white-space: nowrap;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    border: 0;
+    text-overflow: ellipsis;
   }
 
-  @media (max-width: 720px) {
+  .s3-status .actions {
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  .s3-status .actions form {
+    display: inline;
+  }
+
+  @media (max-width: 600px) {
     .s3-status .card-content {
-      padding: 1.5rem;
+      padding: 1.5rem 1.25rem;
     }
 
-    .s3-status .status-meta {
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    }
-
-    .s3-status .section-block {
-      padding: 1.1rem 1.2rem;
-    }
-
-    .s3-status .table-wrapper {
-      margin: 0 -1rem;
-      padding: 0 1rem;
-      overflow-x: auto;
-    }
-
-    .s3-status table {
-      min-width: 520px;
-    }
-
-    .s3-status table td,
-    .s3-status table th {
-      padding: 0.75rem 0.85rem;
-      word-break: break-word;
-    }
-
-    .s3-status table td .truncate {
-      max-width: 240px;
-      white-space: normal;
-      text-overflow: clip;
+    .s3-status .stat-grid {
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     }
   }
 </style>
@@ -320,50 +163,46 @@ WEB_STATUS_TEMPLATE = """
 
   <div class="card">
     <div class="card-content">
-      <h2 class="card-title">Status Overview</h2>
-      <div class="section-block">
-        <h3 class="section-heading">Summary</h3>
-        <div class="status-meta">
-          <div class="status-chip">
-            <span class="label">Status file</span>
-            <span class="value mono">{{ status_path }}</span>
-          </div>
-          <div class="status-chip">
-            <span class="label">Exists</span>
-            <span class="value">{{ 'Yes' if status_exists else 'No' }}</span>
-          </div>
-          <div class="status-chip">
-            <span class="label">Last updated</span>
-            <span class="value">{{ status_mtime or 'Never' }}</span>
-          </div>
-          <div class="status-chip">
-            <span class="label">Total uploaded (unique)</span>
-            <span class="value">{{ status_summary.total_uploaded }}</span>
-          </div>
-          <div class="status-chip">
-            <span class="label">Last upload</span>
-            <span class="value">{{ status_summary.last_upload }}</span>
-          </div>
-          <div class="status-chip">
-            <span class="label">Total handshakes found</span>
-            <span class="value">{{ status_summary.total_handshakes }}</span>
-          </div>
-          <div class="status-chip">
-            <span class="label">Pending uploads</span>
-            <span class="value">{{ status_summary.pending_count }}</span>
-          </div>
-          <div class="status-chip">
-            <span class="label">Tracked records</span>
-            <span class="value">{{ uploaded_records|length }}</span>
-          </div>
+      <span class="card-title">Status Overview</span>
+      <div class="stat-grid">
+        <div class="stat">
+          <span class="label">Status file</span>
+          <span class="value mono">{{ status_path }}</span>
+        </div>
+        <div class="stat">
+          <span class="label">Exists</span>
+          <span class="value">{{ 'Yes' if status_exists else 'No' }}</span>
+        </div>
+        <div class="stat">
+          <span class="label">Last updated</span>
+          <span class="value">{{ status_mtime or 'Never' }}</span>
+        </div>
+        <div class="stat">
+          <span class="label">Total uploaded</span>
+          <span class="value">{{ status_summary.total_uploaded }}</span>
+        </div>
+        <div class="stat">
+          <span class="label">Last upload</span>
+          <span class="value">{{ status_summary.last_upload }}</span>
+        </div>
+        <div class="stat">
+          <span class="label">Handshakes found</span>
+          <span class="value">{{ status_summary.total_handshakes }}</span>
+        </div>
+        <div class="stat">
+          <span class="label">Pending uploads</span>
+          <span class="value">{{ status_summary.pending_count }}</span>
+        </div>
+        <div class="stat">
+          <span class="label">Tracked records</span>
+          <span class="value">{{ uploaded_records|length }}</span>
         </div>
       </div>
-      <div class="section-block">
-        <h3 class="section-heading">Status JSON</h3>
-        <p class="section-text">Download the latest status snapshot to inspect the raw records.</p>
-        <a href="{{ status_download_url }}" class="download-link" download>
-          <i class="material-icons" aria-hidden="true">download</i>
-          <span>Download status JSON</span>
+      <div class="download-actions">
+        <span class="grey-text text-darken-1">Latest status snapshot:</span>
+        <a href="{{ status_download_url }}" class="btn-small blue darken-2 waves-effect waves-light" download>
+          <i class="material-icons left" aria-hidden="true">download</i>
+          Download JSON
         </a>
       </div>
     </div>
@@ -371,52 +210,46 @@ WEB_STATUS_TEMPLATE = """
 
   <div class="card">
     <div class="card-content">
-      <h2 class="card-title">Tracked Uploads</h2>
+      <span class="card-title">Tracked Uploads</span>
       {% if uploaded_records %}
-      <div class="section-block">
-        <h3 class="section-heading">Records</h3>
-        <div class="table-wrapper">
-          <table class="responsive-table striped highlight">
-            <thead>
-              <tr>
-                <th scope="col">File</th>
-                <th scope="col">Checksum</th>
-                <th scope="col">Size</th>
-                <th scope="col">Uploaded</th>
-                <th scope="col">Last Updated</th>
-                <th scope="col" class="right-align">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for record in uploaded_records %}
-              <tr>
-                <td data-label="File"><span class="truncate mono">{{ record.display_path }}</span></td>
-                <td data-label="Checksum"><code>{{ record.display_checksum }}</code></td>
-                <td data-label="Size">{{ record.display_size }}</td>
-                <td data-label="Uploaded">{{ record.uploaded_at }}</td>
-                <td data-label="Last Updated">{{ record.updated_at }}</td>
-                <td data-label="Actions" class="right-align">
-                  <form method="post" action="{{ page_url }}" class="inline-form">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <input type="hidden" name="action" value="clear">
-                    <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
-                    <button type="submit" class="action-btn waves-effect" title="Clear this record">
-                      <i class="material-icons" aria-hidden="true">delete</i>
-                      <span class="sr-only">Clear this record</span>
-                    </button>
-                  </form>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+      <div class="table-wrapper">
+        <table class="highlight responsive-table">
+          <thead>
+            <tr>
+              <th scope="col">File</th>
+              <th scope="col">Checksum</th>
+              <th scope="col">Size</th>
+              <th scope="col">Uploaded</th>
+              <th scope="col">Updated</th>
+              <th scope="col" class="actions">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for record in uploaded_records %}
+            <tr>
+              <td data-label="File"><span class="truncate mono">{{ record.display_path }}</span></td>
+              <td data-label="Checksum"><span class="mono">{{ record.display_checksum }}</span></td>
+              <td data-label="Size">{{ record.display_size }}</td>
+              <td data-label="Uploaded">{{ record.uploaded_at }}</td>
+              <td data-label="Updated">{{ record.updated_at }}</td>
+              <td data-label="Action" class="actions">
+                <form method="post" action="{{ page_url }}">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <input type="hidden" name="action" value="clear">
+                  <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
+                  <button type="submit" class="btn-small red waves-effect waves-light">
+                    <i class="material-icons left" aria-hidden="true">delete</i>
+                    Clear
+                  </button>
+                </form>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
       {% else %}
-      <div class="section-block">
-        <h3 class="section-heading">Records</h3>
-        <p class="section-text">No upload records available.</p>
-      </div>
+      <p class="grey-text text-darken-1">No upload records available.</p>
       {% endif %}
     </div>
   </div>

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -49,9 +49,20 @@ WEB_STATUS_TEMPLATE = """
   }
 
   .s3-status .card-title {
-    margin-bottom: 1rem;
+    margin: 0 0 1rem;
     font-weight: 600;
     color: #263238;
+    font-size: 1.55rem;
+    line-height: 1.3;
+  }
+
+  .s3-status .section-heading {
+    margin: 0 0 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #455a64;
   }
 
   .s3-status .status-meta {
@@ -85,12 +96,14 @@ WEB_STATUS_TEMPLATE = """
     text-decoration: none;
   }
 
-  .s3-status .card-action {
-    display: flex;
-    justify-content: flex-end;
+  .s3-status .status-download {
+    margin-top: 2rem;
   }
 
-  .s3-status .card-action a {
+  .s3-status .status-download a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
     color: #1a237e;
     text-decoration: underline;
     font-weight: 500;
@@ -235,7 +248,7 @@ WEB_STATUS_TEMPLATE = """
 
   <div class="card">
     <div class="card-content">
-      <span class="card-title">Status Overview</span>
+      <h2 class="card-title">Status Overview</h2>
       <div class="status-meta">
         <div class="status-chip">
           <span class="label">Status file</span>
@@ -270,15 +283,16 @@ WEB_STATUS_TEMPLATE = """
           <span class="value">{{ uploaded_records|length }}</span>
         </div>
       </div>
-    </div>
-    <div class="card-action">
-      <a href="{{ status_download_url }}" download>Download status JSON</a>
+      <div class="status-download">
+        <h3 class="section-heading">Status JSON</h3>
+        <a href="{{ status_download_url }}" download>Download status JSON</a>
+      </div>
     </div>
   </div>
 
   <div class="card">
     <div class="card-content">
-      <span class="card-title">Tracked Uploads</span>
+      <h2 class="card-title">Tracked Uploads</h2>
       {% if uploaded_records %}
       <div class="table-wrapper">
         <table class="responsive-table striped highlight">

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -10,6 +10,7 @@ import pwnagotchi.plugins as plugins
 import pwnagotchi
 import logging
 import datetime
+import json
 import os
 import subprocess
 import time
@@ -38,15 +39,18 @@ class PwnS3Upload(plugins.Plugin):
         self.ready = False
         self.options = dict()
         self._handshakes_dir = '/home/pi/handshakes'  # Default path
+        self._status_path = '/root/.s3_uploads'
         try:
-            self.report = StatusFile('/root/.s3_uploads', data_format='json')
+            self.report = StatusFile(self._status_path, data_format='json')
         except JSONDecodeError:
-            os.remove('/root/.s3_uploads')
-            self.report = StatusFile('/root/.s3_uploads', data_format='json')
+            os.remove(self._status_path)
+            self.report = StatusFile(self._status_path, data_format='json')
         self.lock = Lock()
 
+        self._status_data = self._load_status_data()
+
         # In-memory checksum cache to avoid recomputing hashes repeatedly
-        persisted_cache = self.report.data_field_or('checksum_cache', default={})
+        persisted_cache = self.status_field_or('checksum_cache', default={})
         if isinstance(persisted_cache, dict):
             self._checksum_cache = dict(persisted_cache)
         else:
@@ -54,6 +58,82 @@ class PwnS3Upload(plugins.Plugin):
         
         # Ensure boto3 dependencies are available
         self.ensure_dependencies()
+
+    def _load_status_data(self):
+        """Return the persisted status data stored on disk."""
+        try:
+            with open(self._status_path, 'r', encoding='utf-8') as handle:
+                data = json.load(handle)
+        except FileNotFoundError:
+            return {}
+        except (OSError, ValueError, TypeError) as exc:
+            self.LogInfo(f"Failed to load status file {self._status_path}: {exc}")
+            return {}
+
+        if isinstance(data, dict):
+            return data
+
+        self.LogInfo(
+            f"Unexpected data format in status file {self._status_path} - resetting cache"
+        )
+        return {}
+
+    def _persist_status_data(self):
+        """Persist the in-memory status data to disk and the StatusFile helper."""
+        tmp_path = f"{self._status_path}.tmp"
+        try:
+            with open(tmp_path, 'w', encoding='utf-8') as handle:
+                json.dump(self._status_data, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            os.replace(tmp_path, self._status_path)
+        except OSError as exc:
+            self.LogInfo(f"Failed to persist status file {self._status_path}: {exc}")
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
+        else:
+            try:
+                self.report.update(data=self._status_data)
+            except Exception as exc:
+                self.LogDebug(f"Unable to sync StatusFile helper: {exc}")
+
+    def _refresh_status_data_from_disk(self):
+        """Reload the status data from disk when external updates occur."""
+        loaded = self._load_status_data()
+        if loaded != self._status_data:
+            self._status_data = loaded
+
+        checksum_cache = self._status_data.get('checksum_cache')
+        if isinstance(checksum_cache, dict):
+            self._checksum_cache = dict(checksum_cache)
+        else:
+            self._checksum_cache = {}
+
+    def status_field_or(self, field, default=None):
+        """Return a status field value without exposing mutable references."""
+        value = self._status_data.get(field, default)
+        if isinstance(value, dict):
+            return dict(value)
+        if isinstance(value, list):
+            return list(value)
+        return value
+
+    def _update_status_data(self, updates):
+        """Merge updates into the status data and persist the result."""
+        if not isinstance(updates, dict):
+            return
+
+        changed = False
+        for key, value in updates.items():
+            if self._status_data.get(key) != value:
+                self._status_data[key] = value
+                changed = True
+
+        if changed:
+            self._persist_status_data()
+            if 'checksum_cache' in updates and isinstance(updates['checksum_cache'], dict):
+                self._checksum_cache = dict(updates['checksum_cache'])
 
     def ensure_dependencies(self):
         """Ensure required dependencies are installed"""
@@ -221,7 +301,7 @@ class PwnS3Upload(plugins.Plugin):
     # Log Functions - Loaded
     def on_loaded(self):
         self.ready = True
-        uploaded_count = len(self.report.data_field_or('uploaded_files', default=[]))
+        uploaded_count = len(self.status_field_or('uploaded_files', default=[]))
         self.LogInfo(f"Pwnagotchi S3 Handshakes Upload Loaded. {uploaded_count} files previously uploaded.")
         
         # Debug: Check if options are loaded at startup
@@ -335,7 +415,7 @@ class PwnS3Upload(plugins.Plugin):
     
     def get_uploaded_records(self):
         """Return normalized upload records stored in the status file."""
-        raw_records = self.report.data_field_or('uploaded_files', default=[])
+        raw_records = self.status_field_or('uploaded_files', default=[])
 
         normalized_records = []
         for item in raw_records:
@@ -357,7 +437,7 @@ class PwnS3Upload(plugins.Plugin):
 
         # Ensure the status file always stores the normalized representation
         if raw_records != normalized_records:
-            self.report.update(data={
+            self._update_status_data({
                 'uploaded_files': normalized_records,
                 'total_uploaded': len(normalized_records)
             })
@@ -434,7 +514,7 @@ class PwnS3Upload(plugins.Plugin):
         ]
         total_unique = len(set(identifiers))
 
-        self.report.update(data={
+        self._update_status_data({
             'uploaded_files': records,
             'last_upload': timestamp,
             'total_uploaded': total_unique
@@ -452,20 +532,29 @@ class PwnS3Upload(plugins.Plugin):
         if not os.path.exists(handshakes_dir):
             return []
 
-        uploaded_checksums = self.get_uploaded_checksums()
-        uploaded_paths = self.get_uploaded_paths()
+        self._refresh_status_data_from_disk()
+        uploaded_records = self.get_uploaded_records()
+        checksum_to_record = {}
+        path_to_record = {}
+        for record in uploaded_records:
+            record_path = record.get('path') or record.get('filename')
+            if record_path:
+                path_to_record[record_path] = record
+            record_checksum = record.get('checksum')
+            if record_checksum:
+                checksum_to_record[record_checksum] = record
 
         checksum_cache = self._checksum_cache
-        if not checksum_cache:
-            checksum_cache = self.report.data_field_or('checksum_cache', default={})
-            if not isinstance(checksum_cache, dict):
-                checksum_cache = {}
-        else:
+        if checksum_cache:
             checksum_cache = dict(checksum_cache)
+        else:
+            persisted_cache = self.status_field_or('checksum_cache', default={})
+            checksum_cache = persisted_cache if isinstance(persisted_cache, dict) else {}
 
         updated_cache = {}
         pending_files = []
         scanned_file_count = 0
+        records_updated = False
 
         for root, dirs, files in os.walk(handshakes_dir):
             dirs.sort()
@@ -514,11 +603,54 @@ class PwnS3Upload(plugins.Plugin):
                 elif cache_entry:
                     updated_cache[relative_path] = cache_entry
 
-                if checksum and checksum in uploaded_checksums:
+                record_for_checksum = checksum_to_record.get(checksum) if checksum else None
+                record_for_path = path_to_record.get(relative_path)
+
+                if record_for_checksum:
+                    current_timestamp = None
+                    existing_path = record_for_checksum.get('path') or record_for_checksum.get('filename')
+                    if existing_path and existing_path != relative_path:
+                        path_to_record.pop(existing_path, None)
+                        record_for_checksum['path'] = relative_path
+                        record_for_checksum['filename'] = os.path.basename(relative_path)
+                        current_timestamp = current_timestamp or self.get_current_datetime()
+                        record_for_checksum['updated_at'] = current_timestamp
+                        records_updated = True
+
+                    if record_for_checksum.get('size') != size:
+                        record_for_checksum['size'] = size
+                        current_timestamp = current_timestamp or self.get_current_datetime()
+                        record_for_checksum['updated_at'] = current_timestamp
+                        records_updated = True
+
+                    if record_for_checksum.get('mtime_ns') != mtime_ns:
+                        record_for_checksum['mtime_ns'] = mtime_ns
+                        current_timestamp = current_timestamp or self.get_current_datetime()
+                        record_for_checksum['updated_at'] = current_timestamp
+                        records_updated = True
+
+                    path_to_record[relative_path] = record_for_checksum
                     self.LogDebug(f"Skipping {relative_path} - checksum already uploaded")
                     continue
 
-                if not checksum and relative_path in uploaded_paths:
+                if record_for_path and checksum:
+                    record_for_path_checksum = record_for_path.get('checksum')
+                    if record_for_path_checksum == checksum or not record_for_path_checksum:
+                        current_timestamp = self.get_current_datetime()
+                        record_for_path['checksum'] = checksum
+                        record_for_path['size'] = size
+                        record_for_path['mtime_ns'] = mtime_ns
+                        record_for_path['path'] = relative_path
+                        record_for_path['filename'] = os.path.basename(relative_path)
+                        record_for_path['updated_at'] = current_timestamp
+                        checksum_to_record[checksum] = record_for_path
+                        records_updated = True
+                        self.LogDebug(
+                            f"Skipping {relative_path} - associated legacy record refreshed"
+                        )
+                        continue
+
+                if not checksum and record_for_path:
                     self.LogDebug(
                         f"Skipping {relative_path} - path already uploaded (legacy tracking)"
                     )
@@ -533,10 +665,22 @@ class PwnS3Upload(plugins.Plugin):
                 })
 
         if checksum_cache != updated_cache:
-            self.report.update(data={'checksum_cache': updated_cache})
+            self._update_status_data({'checksum_cache': updated_cache})
             self._checksum_cache = updated_cache
         else:
             self._checksum_cache = checksum_cache
+
+        if records_updated:
+            identifiers = [
+                record.get('checksum') or record.get('path') or record.get('filename')
+                for record in uploaded_records
+                if record.get('checksum') or record.get('path') or record.get('filename')
+            ]
+            total_unique = len(set(identifiers))
+            self._update_status_data({
+                'uploaded_files': uploaded_records,
+                'total_uploaded': total_unique
+            })
 
         pending_files.sort(key=lambda item: (item.get('mtime_ns') or 0, item['path']))
         self.LogDebug(
@@ -546,6 +690,7 @@ class PwnS3Upload(plugins.Plugin):
     
     # Get upload statistics for review
     def get_upload_stats(self):
+        self._refresh_status_data_from_disk()
         uploaded_records = self.get_uploaded_records()
         all_files = self.get_handshake_files()
         pending_files = self.collect_pending_uploads()
@@ -562,7 +707,7 @@ class PwnS3Upload(plugins.Plugin):
             'pending_count': len(pending_files),
             'uploaded_files': uploaded_file_names,
             'pending_files': pending_file_names,
-            'last_upload': self.report.data_field_or('last_upload', 'Never')
+            'last_upload': self.status_field_or('last_upload', 'Never')
         }
     
     # Get plugin configuration with defaults
@@ -863,7 +1008,7 @@ class PwnS3Upload(plugins.Plugin):
 
                     # Update status report
                     uploaded_records = self.get_uploaded_records()
-                    self.report.update(data={
+                    self._update_status_data({
                         'last_upload_attempt': self.get_current_datetime(),
                         'last_upload_success': success,
                         'uploaded_files': uploaded_records,

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -44,110 +44,267 @@ WEB_STATUS_TEMPLATE = """
 {% block styles %}
 {{ super() }}
 <style>
+  .s3-status {
+    --s3-surface: #ffffff;
+    --s3-border: rgba(176, 190, 197, 0.55);
+    --s3-muted: #455a64;
+    --s3-heading: #263238;
+    --s3-chip: rgba(236, 239, 241, 0.55);
+    --s3-chip-border: rgba(120, 144, 156, 0.22);
+  }
+
   .s3-status .card {
     margin-bottom: 2rem;
+    border-radius: 18px;
+    border: 1px solid var(--s3-border);
+    box-shadow: 0 14px 28px rgba(38, 50, 56, 0.08);
+    background: var(--s3-surface);
+  }
+
+  .s3-status .card-content {
+    padding: 2rem;
   }
 
   .s3-status .card-title {
-    font-size: 1.6rem;
-    margin-bottom: 1.5rem;
+    margin: 0 0 1.5rem;
+    font-weight: 600;
+    color: var(--s3-heading);
+    font-size: 1.55rem;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
   }
 
-  .s3-status .stat-grid {
+  .s3-status .section-block {
+    border-radius: 14px;
+    border: 1px solid var(--s3-border);
+    background: rgba(236, 239, 241, 0.4);
+    padding: 1.35rem 1.5rem;
+    margin-top: 1.5rem;
+  }
+
+  .s3-status .section-block:first-of-type {
+    margin-top: 0;
+  }
+
+  .s3-status .section-heading {
+    margin: 0 0 0.85rem;
+    font-size: 0.92rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--s3-muted);
+  }
+
+  .s3-status .section-text {
+    margin: 0 0 1rem;
+    color: #37474f;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+
+  .s3-status .status-meta {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 1rem;
-    margin-bottom: 1.5rem;
   }
 
-  .s3-status .stat {
-    border: 1px solid #e0e0e0;
+  .s3-status .status-chip {
+    background: var(--s3-chip);
+    border-radius: 12px;
+    padding: 0.9rem 1.1rem;
+    line-height: 1.45;
+    box-shadow: inset 0 0 0 1px var(--s3-chip-border);
+  }
+
+  .s3-status .status-chip .label {
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    color: #546e7a;
+    display: block;
+    margin-bottom: 0.35rem;
+  }
+
+  .s3-status .status-chip .value {
+    font-weight: 600;
+    font-size: 0.95rem;
+    word-break: break-word;
+    color: var(--s3-heading);
+  }
+
+  .s3-status .download-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: #1a237e;
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.45rem 0.85rem;
     border-radius: 8px;
-    background: #fafafa;
+    transition: background 150ms ease, color 150ms ease;
+  }
+
+  .s3-status .download-link:hover,
+  .s3-status .download-link:focus {
+    background: rgba(26, 35, 126, 0.12);
+    color: #0d47a1;
+  }
+
+  .s3-status .download-link .material-icons {
+    font-size: 1.1rem;
+  }
+
+  .s3-status .table-wrapper {
+    margin-top: 0.5rem;
+    overflow-x: auto;
+    border-radius: 12px;
+    border: 1px solid rgba(176, 190, 197, 0.6);
+    background: #fff;
+  }
+
+  .s3-status table {
+    margin-bottom: 0;
+    width: 100%;
+    min-width: 640px;
+    border-collapse: collapse;
+  }
+
+  .s3-status table thead th {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.72rem;
+    color: var(--s3-muted);
+    background-color: rgba(236, 239, 241, 0.8);
+    border-bottom: 1px solid rgba(120, 144, 156, 0.3);
+  }
+
+  .s3-status table td,
+  .s3-status table th {
     padding: 0.85rem 1rem;
   }
 
-  .s3-status .stat .label {
-    display: block;
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: #546e7a;
-    margin-bottom: 0.25rem;
+  .s3-status table tbody tr:nth-child(even) {
+    background-color: rgba(236, 239, 241, 0.35);
   }
 
-  .s3-status .stat .value {
-    font-weight: 600;
-    color: #263238;
-    word-break: break-word;
+  .s3-status table tbody tr:hover {
+    background-color: rgba(207, 216, 220, 0.35);
+  }
+
+  .s3-status table tbody td {
+    font-size: 0.9rem;
+    color: #37474f;
+  }
+
+  .s3-status td code,
+  .s3-status td .mono {
+    word-break: break-all;
+    font-family: "Roboto Mono", "Source Code Pro", monospace;
+    font-size: 0.85rem;
+    color: var(--s3-heading);
   }
 
   .s3-status .mono {
     font-family: "Roboto Mono", "Source Code Pro", monospace;
   }
 
-  .s3-status .download-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .s3-status .table-wrapper {
-    overflow-x: auto;
-  }
-
-  .s3-status table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  .s3-status thead th {
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    font-size: 0.75rem;
-    color: #546e7a;
-    background: #eceff1;
-  }
-
-  .s3-status th,
-  .s3-status td {
-    padding: 0.75rem 0.9rem;
-  }
-
-  .s3-status tbody tr:nth-child(even) {
-    background: #f7f9fa;
-  }
-
-  .s3-status tbody td {
-    color: #37474f;
-    font-size: 0.9rem;
+  .s3-status td code {
+    background-color: rgba(207, 216, 220, 0.35);
+    padding: 0.2rem 0.35rem;
+    border-radius: 4px;
+    display: inline-block;
   }
 
   .s3-status .truncate {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     max-width: 100%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
-  .s3-status .actions {
+  .s3-status .inline-form {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .s3-status .inline-form .action-btn {
+    width: 42px;
+    height: 42px;
+    border-radius: 10px;
+    border: none;
+    background: #d32f2f;
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    cursor: pointer;
+  }
+
+  .s3-status .inline-form .action-btn .material-icons {
+    font-size: 1.15rem;
+  }
+
+  .s3-status .inline-form .action-btn:hover,
+  .s3-status .inline-form .action-btn:focus {
+    background: #b71c1c;
+    box-shadow: 0 4px 12px rgba(183, 28, 28, 0.35);
+    transform: translateY(-1px);
+  }
+
+  .s3-status .inline-form .action-btn:focus-visible {
+    outline: 2px solid #ffcdd2;
+    outline-offset: 2px;
+  }
+
+  .s3-status th.right-align,
+  .s3-status td.right-align {
     text-align: right;
-    white-space: nowrap;
   }
 
-  .s3-status .actions form {
-    display: inline;
+  .s3-status .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
   }
 
-  @media (max-width: 600px) {
+  @media (max-width: 720px) {
     .s3-status .card-content {
-      padding: 1.5rem 1.25rem;
+      padding: 1.5rem;
     }
 
-    .s3-status .stat-grid {
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    .s3-status .status-meta {
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .s3-status .section-block {
+      padding: 1.1rem 1.2rem;
+    }
+
+    .s3-status .table-wrapper {
+      margin: 0 -1rem;
+      padding: 0 1rem;
+      overflow-x: auto;
+    }
+
+    .s3-status table {
+      min-width: 520px;
+    }
+
+    .s3-status table td,
+    .s3-status table th {
+      padding: 0.75rem 0.85rem;
+      word-break: break-word;
+    }
+
+    .s3-status table td .truncate {
+      max-width: 240px;
+      white-space: normal;
+      text-overflow: clip;
     }
   }
 </style>
@@ -163,46 +320,50 @@ WEB_STATUS_TEMPLATE = """
 
   <div class="card">
     <div class="card-content">
-      <span class="card-title">Status Overview</span>
-      <div class="stat-grid">
-        <div class="stat">
-          <span class="label">Status file</span>
-          <span class="value mono">{{ status_path }}</span>
-        </div>
-        <div class="stat">
-          <span class="label">Exists</span>
-          <span class="value">{{ 'Yes' if status_exists else 'No' }}</span>
-        </div>
-        <div class="stat">
-          <span class="label">Last updated</span>
-          <span class="value">{{ status_mtime or 'Never' }}</span>
-        </div>
-        <div class="stat">
-          <span class="label">Total uploaded</span>
-          <span class="value">{{ status_summary.total_uploaded }}</span>
-        </div>
-        <div class="stat">
-          <span class="label">Last upload</span>
-          <span class="value">{{ status_summary.last_upload }}</span>
-        </div>
-        <div class="stat">
-          <span class="label">Handshakes found</span>
-          <span class="value">{{ status_summary.total_handshakes }}</span>
-        </div>
-        <div class="stat">
-          <span class="label">Pending uploads</span>
-          <span class="value">{{ status_summary.pending_count }}</span>
-        </div>
-        <div class="stat">
-          <span class="label">Tracked records</span>
-          <span class="value">{{ uploaded_records|length }}</span>
+      <h2 class="card-title">Status Overview</h2>
+      <div class="section-block">
+        <h3 class="section-heading">Summary</h3>
+        <div class="status-meta">
+          <div class="status-chip">
+            <span class="label">Status file</span>
+            <span class="value mono">{{ status_path }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Exists</span>
+            <span class="value">{{ 'Yes' if status_exists else 'No' }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Last updated</span>
+            <span class="value">{{ status_mtime or 'Never' }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Total uploaded (unique)</span>
+            <span class="value">{{ status_summary.total_uploaded }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Last upload</span>
+            <span class="value">{{ status_summary.last_upload }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Total handshakes found</span>
+            <span class="value">{{ status_summary.total_handshakes }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Pending uploads</span>
+            <span class="value">{{ status_summary.pending_count }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Tracked records</span>
+            <span class="value">{{ uploaded_records|length }}</span>
+          </div>
         </div>
       </div>
-      <div class="download-actions">
-        <span class="grey-text text-darken-1">Latest status snapshot:</span>
-        <a href="{{ status_download_url }}" class="btn-small blue darken-2 waves-effect waves-light" download>
-          <i class="material-icons left" aria-hidden="true">download</i>
-          Download JSON
+      <div class="section-block">
+        <h3 class="section-heading">Status JSON</h3>
+        <p class="section-text">Download the latest status snapshot to inspect the raw records.</p>
+        <a href="{{ status_download_url }}" class="download-link" download>
+          <i class="material-icons" aria-hidden="true">download</i>
+          <span>Download status JSON</span>
         </a>
       </div>
     </div>
@@ -210,46 +371,52 @@ WEB_STATUS_TEMPLATE = """
 
   <div class="card">
     <div class="card-content">
-      <span class="card-title">Tracked Uploads</span>
+      <h2 class="card-title">Tracked Uploads</h2>
       {% if uploaded_records %}
-      <div class="table-wrapper">
-        <table class="highlight responsive-table">
-          <thead>
-            <tr>
-              <th scope="col">File</th>
-              <th scope="col">Checksum</th>
-              <th scope="col">Size</th>
-              <th scope="col">Uploaded</th>
-              <th scope="col">Updated</th>
-              <th scope="col" class="actions">Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for record in uploaded_records %}
-            <tr>
-              <td data-label="File"><span class="truncate mono">{{ record.display_path }}</span></td>
-              <td data-label="Checksum"><span class="mono">{{ record.display_checksum }}</span></td>
-              <td data-label="Size">{{ record.display_size }}</td>
-              <td data-label="Uploaded">{{ record.uploaded_at }}</td>
-              <td data-label="Updated">{{ record.updated_at }}</td>
-              <td data-label="Action" class="actions">
-                <form method="post" action="{{ page_url }}">
-                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                  <input type="hidden" name="action" value="clear">
-                  <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
-                  <button type="submit" class="btn-small red waves-effect waves-light">
-                    <i class="material-icons left" aria-hidden="true">delete</i>
-                    Clear
-                  </button>
-                </form>
-              </td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+      <div class="section-block">
+        <h3 class="section-heading">Records</h3>
+        <div class="table-wrapper">
+          <table class="responsive-table striped highlight">
+            <thead>
+              <tr>
+                <th scope="col">File</th>
+                <th scope="col">Checksum</th>
+                <th scope="col">Size</th>
+                <th scope="col">Uploaded</th>
+                <th scope="col">Last Updated</th>
+                <th scope="col" class="right-align">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for record in uploaded_records %}
+              <tr>
+                <td data-label="File"><span class="truncate mono">{{ record.display_path }}</span></td>
+                <td data-label="Checksum"><code>{{ record.display_checksum }}</code></td>
+                <td data-label="Size">{{ record.display_size }}</td>
+                <td data-label="Uploaded">{{ record.uploaded_at }}</td>
+                <td data-label="Last Updated">{{ record.updated_at }}</td>
+                <td data-label="Actions" class="right-align">
+                  <form method="post" action="{{ page_url }}" class="inline-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <input type="hidden" name="action" value="clear">
+                    <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
+                    <button type="submit" class="action-btn waves-effect" title="Clear this record">
+                      <i class="material-icons" aria-hidden="true">delete</i>
+                      <span class="sr-only">Clear this record</span>
+                    </button>
+                  </form>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       </div>
       {% else %}
-      <p class="grey-text text-darken-1">No upload records available.</p>
+      <div class="section-block">
+        <h3 class="section-heading">Records</h3>
+        <p class="section-text">No upload records available.</p>
+      </div>
       {% endif %}
     </div>
   </div>

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -90,12 +90,10 @@ WEB_STATUS_TEMPLATE = """
     justify-content: flex-end;
   }
 
-  .s3-status .card-action .btn {
-    background-color: #455a64;
-  }
-
-  .s3-status .card-action .btn:hover {
-    background-color: #37474f;
+  .s3-status .card-action a {
+    color: #1a237e;
+    text-decoration: underline;
+    font-weight: 500;
   }
 
   .s3-status .table-wrapper {
@@ -170,35 +168,26 @@ WEB_STATUS_TEMPLATE = """
   }
 
   .s3-status .inline-form .action-btn {
-    padding: 0.45rem 0.95rem;
-    border-radius: 6px;
-    border: none;
-    background: #e53935;
-    color: #fff;
+    padding: 0.4rem 0.95rem;
+    border-radius: 4px;
+    border: 1px solid #d32f2f;
+    background: #fff;
+    color: #d32f2f;
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
+    justify-content: center;
     font-weight: 600;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    transition: background-color 150ms ease, box-shadow 150ms ease;
-    box-shadow: 0 2px 4px rgba(229, 57, 53, 0.25);
+    letter-spacing: 0.01em;
+    text-transform: none;
+    transition: background-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
     cursor: pointer;
   }
 
   .s3-status .inline-form .action-btn:hover,
   .s3-status .inline-form .action-btn:focus {
-    background: #c62828;
-    box-shadow: 0 4px 10px rgba(198, 40, 40, 0.35);
-  }
-
-  .s3-status .inline-form .action-btn i {
-    font-size: 1.15rem;
-    color: inherit;
-  }
-
-  .s3-status .inline-form .action-btn .label {
-    font-size: 0.78rem;
+    background: #d32f2f;
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(211, 47, 47, 0.35);
   }
 
   .s3-status th.right-align,
@@ -283,7 +272,7 @@ WEB_STATUS_TEMPLATE = """
       </div>
     </div>
     <div class="card-action">
-      <a href="{{ status_download_url }}" class="btn" download>Download status JSON</a>
+      <a href="{{ status_download_url }}" download>Download status JSON</a>
     </div>
   </div>
 
@@ -316,10 +305,7 @@ WEB_STATUS_TEMPLATE = """
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="action" value="clear">
                   <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
-                  <button type="submit" class="action-btn waves-effect waves-light" title="Remove this record" aria-label="Remove this record">
-                    <i class="material-icons" aria-hidden="true">delete</i>
-                    <span class="label">Clear</span>
-                  </button>
+                  <button type="submit" class="action-btn waves-effect" title="Clear this record" aria-label="Clear this record">Clear</button>
                 </form>
               </td>
             </tr>

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -44,25 +44,62 @@ WEB_STATUS_TEMPLATE = """
 {% block styles %}
 {{ super() }}
 <style>
+  .s3-status {
+    --s3-surface: #ffffff;
+    --s3-border: rgba(176, 190, 197, 0.55);
+    --s3-muted: #455a64;
+    --s3-heading: #263238;
+    --s3-chip: rgba(236, 239, 241, 0.55);
+    --s3-chip-border: rgba(120, 144, 156, 0.22);
+  }
+
   .s3-status .card {
     margin-bottom: 2rem;
+    border-radius: 18px;
+    border: 1px solid var(--s3-border);
+    box-shadow: 0 14px 28px rgba(38, 50, 56, 0.08);
+    background: var(--s3-surface);
+  }
+
+  .s3-status .card-content {
+    padding: 2rem;
   }
 
   .s3-status .card-title {
-    margin: 0 0 1rem;
+    margin: 0 0 1.5rem;
     font-weight: 600;
-    color: #263238;
+    color: var(--s3-heading);
     font-size: 1.55rem;
     line-height: 1.3;
+    letter-spacing: -0.01em;
+  }
+
+  .s3-status .section-block {
+    border-radius: 14px;
+    border: 1px solid var(--s3-border);
+    background: rgba(236, 239, 241, 0.4);
+    padding: 1.35rem 1.5rem;
+    margin-top: 1.5rem;
+  }
+
+  .s3-status .section-block:first-of-type {
+    margin-top: 0;
   }
 
   .s3-status .section-heading {
-    margin: 0 0 0.75rem;
-    font-size: 1rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
+    margin: 0 0 0.85rem;
+    font-size: 0.92rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: #455a64;
+    color: var(--s3-muted);
+  }
+
+  .s3-status .section-text {
+    margin: 0 0 1rem;
+    color: #37474f;
+    font-size: 0.95rem;
+    line-height: 1.5;
   }
 
   .s3-status .status-meta {
@@ -72,11 +109,11 @@ WEB_STATUS_TEMPLATE = """
   }
 
   .s3-status .status-chip {
-    background: #eceff1;
+    background: var(--s3-chip);
     border-radius: 12px;
     padding: 0.9rem 1.1rem;
     line-height: 1.45;
-    box-shadow: inset 0 0 0 1px rgba(120, 144, 156, 0.18);
+    box-shadow: inset 0 0 0 1px var(--s3-chip-border);
   }
 
   .s3-status .status-chip .label {
@@ -92,28 +129,37 @@ WEB_STATUS_TEMPLATE = """
     font-weight: 600;
     font-size: 0.95rem;
     word-break: break-word;
-    color: #263238;
-    text-decoration: none;
+    color: var(--s3-heading);
   }
 
-  .s3-status .status-download {
-    margin-top: 2rem;
-  }
-
-  .s3-status .status-download a {
+  .s3-status .download-link {
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.4rem;
     color: #1a237e;
-    text-decoration: underline;
-    font-weight: 500;
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.45rem 0.85rem;
+    border-radius: 8px;
+    transition: background 150ms ease, color 150ms ease;
+  }
+
+  .s3-status .download-link:hover,
+  .s3-status .download-link:focus {
+    background: rgba(26, 35, 126, 0.12);
+    color: #0d47a1;
+  }
+
+  .s3-status .download-link .material-icons {
+    font-size: 1.1rem;
   }
 
   .s3-status .table-wrapper {
-    margin-top: 1rem;
+    margin-top: 0.5rem;
     overflow-x: auto;
     border-radius: 12px;
     border: 1px solid rgba(176, 190, 197, 0.6);
+    background: #fff;
   }
 
   .s3-status table {
@@ -127,8 +173,8 @@ WEB_STATUS_TEMPLATE = """
     text-transform: uppercase;
     letter-spacing: 0.08em;
     font-size: 0.72rem;
-    color: #455a64;
-    background-color: #eceff1;
+    color: var(--s3-muted);
+    background-color: rgba(236, 239, 241, 0.8);
     border-bottom: 1px solid rgba(120, 144, 156, 0.3);
   }
 
@@ -142,7 +188,7 @@ WEB_STATUS_TEMPLATE = """
   }
 
   .s3-status table tbody tr:hover {
-    background-color: rgba(207, 216, 220, 0.5);
+    background-color: rgba(207, 216, 220, 0.35);
   }
 
   .s3-status table tbody td {
@@ -155,7 +201,7 @@ WEB_STATUS_TEMPLATE = """
     word-break: break-all;
     font-family: "Roboto Mono", "Source Code Pro", monospace;
     font-size: 0.85rem;
-    color: #263238;
+    color: var(--s3-heading);
   }
 
   .s3-status .mono {
@@ -181,26 +227,33 @@ WEB_STATUS_TEMPLATE = """
   }
 
   .s3-status .inline-form .action-btn {
-    padding: 0.4rem 0.95rem;
-    border-radius: 4px;
-    border: 1px solid #d32f2f;
-    background: #fff;
-    color: #d32f2f;
+    width: 42px;
+    height: 42px;
+    border-radius: 10px;
+    border: none;
+    background: #d32f2f;
+    color: #fff;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-weight: 600;
-    letter-spacing: 0.01em;
-    text-transform: none;
-    transition: background-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
+    transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
     cursor: pointer;
+  }
+
+  .s3-status .inline-form .action-btn .material-icons {
+    font-size: 1.15rem;
   }
 
   .s3-status .inline-form .action-btn:hover,
   .s3-status .inline-form .action-btn:focus {
-    background: #d32f2f;
-    color: #fff;
-    box-shadow: 0 2px 6px rgba(211, 47, 47, 0.35);
+    background: #b71c1c;
+    box-shadow: 0 4px 12px rgba(183, 28, 28, 0.35);
+    transform: translateY(-1px);
+  }
+
+  .s3-status .inline-form .action-btn:focus-visible {
+    outline: 2px solid #ffcdd2;
+    outline-offset: 2px;
   }
 
   .s3-status th.right-align,
@@ -208,9 +261,28 @@ WEB_STATUS_TEMPLATE = """
     text-align: right;
   }
 
+  .s3-status .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+  }
+
   @media (max-width: 720px) {
+    .s3-status .card-content {
+      padding: 1.5rem;
+    }
+
     .s3-status .status-meta {
       grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .s3-status .section-block {
+      padding: 1.1rem 1.2rem;
     }
 
     .s3-status .table-wrapper {
@@ -249,43 +321,50 @@ WEB_STATUS_TEMPLATE = """
   <div class="card">
     <div class="card-content">
       <h2 class="card-title">Status Overview</h2>
-      <div class="status-meta">
-        <div class="status-chip">
-          <span class="label">Status file</span>
-          <span class="value mono">{{ status_path }}</span>
-        </div>
-        <div class="status-chip">
-          <span class="label">Exists</span>
-          <span class="value">{{ 'Yes' if status_exists else 'No' }}</span>
-        </div>
-        <div class="status-chip">
-          <span class="label">Last updated</span>
-          <span class="value">{{ status_mtime or 'Never' }}</span>
-        </div>
-        <div class="status-chip">
-          <span class="label">Total uploaded (unique)</span>
-          <span class="value">{{ status_summary.total_uploaded }}</span>
-        </div>
-        <div class="status-chip">
-          <span class="label">Last upload</span>
-          <span class="value">{{ status_summary.last_upload }}</span>
-        </div>
-        <div class="status-chip">
-          <span class="label">Total handshakes found</span>
-          <span class="value">{{ status_summary.total_handshakes }}</span>
-        </div>
-        <div class="status-chip">
-          <span class="label">Pending uploads</span>
-          <span class="value">{{ status_summary.pending_count }}</span>
-        </div>
-        <div class="status-chip">
-          <span class="label">Tracked records</span>
-          <span class="value">{{ uploaded_records|length }}</span>
+      <div class="section-block">
+        <h3 class="section-heading">Summary</h3>
+        <div class="status-meta">
+          <div class="status-chip">
+            <span class="label">Status file</span>
+            <span class="value mono">{{ status_path }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Exists</span>
+            <span class="value">{{ 'Yes' if status_exists else 'No' }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Last updated</span>
+            <span class="value">{{ status_mtime or 'Never' }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Total uploaded (unique)</span>
+            <span class="value">{{ status_summary.total_uploaded }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Last upload</span>
+            <span class="value">{{ status_summary.last_upload }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Total handshakes found</span>
+            <span class="value">{{ status_summary.total_handshakes }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Pending uploads</span>
+            <span class="value">{{ status_summary.pending_count }}</span>
+          </div>
+          <div class="status-chip">
+            <span class="label">Tracked records</span>
+            <span class="value">{{ uploaded_records|length }}</span>
+          </div>
         </div>
       </div>
-      <div class="status-download">
+      <div class="section-block">
         <h3 class="section-heading">Status JSON</h3>
-        <a href="{{ status_download_url }}" download>Download status JSON</a>
+        <p class="section-text">Download the latest status snapshot to inspect the raw records.</p>
+        <a href="{{ status_download_url }}" class="download-link" download>
+          <i class="material-icons" aria-hidden="true">download</i>
+          <span>Download status JSON</span>
+        </a>
       </div>
     </div>
   </div>
@@ -294,41 +373,50 @@ WEB_STATUS_TEMPLATE = """
     <div class="card-content">
       <h2 class="card-title">Tracked Uploads</h2>
       {% if uploaded_records %}
-      <div class="table-wrapper">
-        <table class="responsive-table striped highlight">
-          <thead>
-            <tr>
-              <th scope="col">File</th>
-              <th scope="col">Checksum</th>
-              <th scope="col">Size</th>
-              <th scope="col">Uploaded</th>
-              <th scope="col">Last Updated</th>
-              <th scope="col" class="right-align">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for record in uploaded_records %}
-            <tr>
-              <td data-label="File"><span class="truncate mono">{{ record.display_path }}</span></td>
-              <td data-label="Checksum"><code>{{ record.display_checksum }}</code></td>
-              <td data-label="Size">{{ record.display_size }}</td>
-              <td data-label="Uploaded">{{ record.uploaded_at }}</td>
-              <td data-label="Last Updated">{{ record.updated_at }}</td>
-              <td data-label="Actions" class="right-align">
-                <form method="post" action="{{ page_url }}" class="inline-form">
-                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                  <input type="hidden" name="action" value="clear">
-                  <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
-                  <button type="submit" class="action-btn waves-effect" title="Clear this record" aria-label="Clear this record">Clear</button>
-                </form>
-              </td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+      <div class="section-block">
+        <h3 class="section-heading">Records</h3>
+        <div class="table-wrapper">
+          <table class="responsive-table striped highlight">
+            <thead>
+              <tr>
+                <th scope="col">File</th>
+                <th scope="col">Checksum</th>
+                <th scope="col">Size</th>
+                <th scope="col">Uploaded</th>
+                <th scope="col">Last Updated</th>
+                <th scope="col" class="right-align">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for record in uploaded_records %}
+              <tr>
+                <td data-label="File"><span class="truncate mono">{{ record.display_path }}</span></td>
+                <td data-label="Checksum"><code>{{ record.display_checksum }}</code></td>
+                <td data-label="Size">{{ record.display_size }}</td>
+                <td data-label="Uploaded">{{ record.uploaded_at }}</td>
+                <td data-label="Last Updated">{{ record.updated_at }}</td>
+                <td data-label="Actions" class="right-align">
+                  <form method="post" action="{{ page_url }}" class="inline-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <input type="hidden" name="action" value="clear">
+                    <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
+                    <button type="submit" class="action-btn waves-effect" title="Clear this record">
+                      <i class="material-icons" aria-hidden="true">delete</i>
+                      <span class="sr-only">Clear this record</span>
+                    </button>
+                  </form>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       </div>
       {% else %}
-      <p class="grey-text text-darken-1">No upload records available.</p>
+      <div class="section-block">
+        <h3 class="section-heading">Records</h3>
+        <p class="section-text">No upload records available.</p>
+      </div>
       {% endif %}
     </div>
   </div>

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -81,7 +81,8 @@ WEB_STATUS_TEMPLATE = """
     font-weight: 600;
     font-size: 0.95rem;
     word-break: break-word;
-    color: #1c313a;
+    color: #263238;
+    text-decoration: none;
   }
 
   .s3-status .card-action {
@@ -90,11 +91,11 @@ WEB_STATUS_TEMPLATE = """
   }
 
   .s3-status .card-action .btn {
-    background-color: #546e7a;
+    background-color: #455a64;
   }
 
   .s3-status .card-action .btn:hover {
-    background-color: #455a64;
+    background-color: #37474f;
   }
 
   .s3-status .table-wrapper {
@@ -146,6 +147,10 @@ WEB_STATUS_TEMPLATE = """
     color: #263238;
   }
 
+  .s3-status .mono {
+    font-family: "Roboto Mono", "Source Code Pro", monospace;
+  }
+
   .s3-status td code {
     background-color: rgba(207, 216, 220, 0.35);
     padding: 0.2rem 0.35rem;
@@ -164,20 +169,31 @@ WEB_STATUS_TEMPLATE = """
     align-items: center;
   }
 
-  .s3-status .inline-form button {
+  .s3-status .inline-form .action-btn {
     padding: 0;
-  }
-
-  .s3-status .inline-form button.icon-only {
     width: 2.5rem;
     height: 2.5rem;
     border-radius: 999px;
+    border: none;
+    background: #e53935;
+    color: #fff;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    transition: background-color 150ms ease, box-shadow 150ms ease;
+    box-shadow: 0 2px 4px rgba(229, 57, 53, 0.3);
+    cursor: pointer;
   }
-  .s3-status .inline-form button.icon-only i {
+
+  .s3-status .inline-form .action-btn:hover,
+  .s3-status .inline-form .action-btn:focus {
+    background: #c62828;
+    box-shadow: 0 4px 8px rgba(198, 40, 40, 0.35);
+  }
+
+  .s3-status .inline-form .action-btn i {
     font-size: 1.25rem;
+    color: inherit;
   }
 
   .s3-status th.right-align,
@@ -263,7 +279,7 @@ WEB_STATUS_TEMPLATE = """
       <div class="status-meta">
         <div class="status-chip">
           <span class="label">Status file</span>
-          <span class="value">{{ status_path }}</span>
+          <span class="value mono">{{ status_path }}</span>
         </div>
         <div class="status-chip">
           <span class="label">Exists</span>
@@ -329,7 +345,7 @@ WEB_STATUS_TEMPLATE = """
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="action" value="clear">
                   <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
-                  <button type="submit" class="btn-flat btn-small waves-effect waves-light red-text text-darken-2 icon-only" title="Remove this record" aria-label="Remove this record">
+                  <button type="submit" class="action-btn waves-effect waves-light" title="Remove this record" aria-label="Remove this record">
                     <i class="material-icons" aria-hidden="true">delete</i>
                   </button>
                 </form>

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -36,31 +36,54 @@ WEB_STATUS_TEMPLATE = """
 {% block title %}S3 Upload Status{% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col s12 m6">
-    <div class="card">
-      <div class="card-content">
-        <span class="card-title">Status Overview</span>
-        <p><strong>Status file:</strong> {{ status_path }}</p>
-        <p><strong>Exists:</strong> {{ 'Yes' if status_exists else 'No' }}</p>
-        <p><strong>Last updated:</strong> {{ status_mtime or 'Never' }}</p>
-        <p><strong>Total uploaded:</strong> {{ status_summary.total_uploaded }}</p>
-        <p><strong>Last upload:</strong> {{ status_summary.last_upload }}</p>
-      </div>
-    </div>
+{% if feedback %}
+<div class="card-panel {{ 'green lighten-5' if feedback.category == 'success' else 'red lighten-5' }}">
+  <span class="{{ 'green-text text-darken-4' if feedback.category == 'success' else 'red-text text-darken-4' }}">{{ feedback.message }}</span>
+</div>
+{% endif %}
+
+<div class="card">
+  <div class="card-content">
+    <span class="card-title">Status Overview</span>
+    <table class="striped">
+      <tbody>
+        <tr>
+          <th scope="row">Status file</th>
+          <td>{{ status_path }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Exists</th>
+          <td>{{ 'Yes' if status_exists else 'No' }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Last updated</th>
+          <td>{{ status_mtime or 'Never' }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Total uploaded (unique)</th>
+          <td>{{ status_summary.total_uploaded }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Last upload</th>
+          <td>{{ status_summary.last_upload }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Total handshakes found</th>
+          <td>{{ status_summary.total_handshakes }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Pending uploads</th>
+          <td>{{ status_summary.pending_count }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Tracked records</th>
+          <td>{{ uploaded_records|length }}</td>
+        </tr>
+      </tbody>
+    </table>
   </div>
-  <div class="col s12 m6">
-    <div class="card">
-      <div class="card-content">
-        <span class="card-title">Pending Summary</span>
-        <p><strong>Total handshakes:</strong> {{ status_summary.total_handshakes }}</p>
-        <p><strong>Pending uploads:</strong> {{ status_summary.pending_count }}</p>
-        <p><strong>Uploaded entries tracked:</strong> {{ uploaded_records|length }}</p>
-      </div>
-      <div class="card-action">
-        <a href="{{ raw_status_url }}" target="_blank">View raw status JSON</a>
-      </div>
-    </div>
+  <div class="card-action">
+    <a href="{{ status_download_url }}" class="btn" download>Download status JSON</a>
   </div>
 </div>
 
@@ -68,36 +91,43 @@ WEB_STATUS_TEMPLATE = """
   <div class="card-content">
     <span class="card-title">Tracked Uploads</span>
     {% if uploaded_records %}
-    <table class="striped responsive-table">
-      <thead>
-        <tr>
-          <th>File</th>
-          <th>Checksum</th>
-          <th>Uploaded At</th>
-          <th>Updated At</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for record in uploaded_records %}
-        <tr>
-          <td>{{ record.path or record.filename }}</td>
-          <td><code>{{ record.checksum or 'n/a' }}</code></td>
-          <td>{{ record.uploaded_at or 'n/a' }}</td>
-          <td>{{ record.updated_at or record.uploaded_at or 'n/a' }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div class="table-responsive">
+      <table class="striped responsive-table">
+        <thead>
+          <tr>
+            <th>File</th>
+            <th>Checksum</th>
+            <th>Size</th>
+            <th>Uploaded</th>
+            <th>Last Updated</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for record in uploaded_records %}
+          <tr>
+            <td>{{ record.display_path }}</td>
+            <td><code>{{ record.display_checksum }}</code></td>
+            <td>{{ record.display_size }}</td>
+            <td>{{ record.uploaded_at }}</td>
+            <td>{{ record.updated_at }}</td>
+            <td>
+              <form method="post" action="{{ page_url }}" style="display:inline">
+                <input type="hidden" name="action" value="clear">
+                <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
+                <button type="submit" class="btn-flat waves-effect red-text text-accent-4" title="Remove this record">
+                  Clear
+                </button>
+              </form>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
     {% else %}
     <p>No upload records available.</p>
     {% endif %}
-  </div>
-</div>
-
-<div class="card">
-  <div class="card-content">
-    <span class="card-title">Raw Status Data</span>
-    <pre style="white-space: pre-wrap">{{ status_json }}</pre>
   </div>
 </div>
 {% endblock %}
@@ -546,6 +576,24 @@ class PwnS3Upload(plugins.Plugin):
             return None
         return sha256.hexdigest()
 
+    @staticmethod
+    def _format_size(num_bytes):
+        """Return a human readable string for a byte count."""
+        if not isinstance(num_bytes, (int, float)) or num_bytes < 0:
+            return 'n/a'
+
+        units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+        size = float(num_bytes)
+        unit_index = 0
+        while size >= 1024 and unit_index < len(units) - 1:
+            size /= 1024.0
+            unit_index += 1
+
+        if unit_index == 0:
+            return f"{int(size)} {units[unit_index]}"
+
+        return f"{size:.2f} {units[unit_index]}"
+
     def track_uploaded_file(self, relative_path, checksum):
         """Record a successfully uploaded file using its checksum."""
         if not relative_path and not checksum:
@@ -597,6 +645,59 @@ class PwnS3Upload(plugins.Plugin):
             f"Recorded upload for {relative_path} "
             f"({'checksum ' + checksum if checksum else 'no checksum'})"
         )
+
+    def clear_uploaded_record(self, identifier):
+        """Remove a tracked upload entry by checksum or path."""
+        if not identifier:
+            return False
+
+        with self.lock:
+            self._refresh_status_data_from_disk()
+            records = self.get_uploaded_records()
+            retained_records = []
+            removed = False
+            removed_paths = set()
+
+            for record in records:
+                record_identifiers = {
+                    record.get('checksum'),
+                    record.get('path'),
+                    record.get('filename')
+                }
+                if identifier in record_identifiers:
+                    removed = True
+                    record_path = record.get('path') or record.get('filename')
+                    if record_path:
+                        removed_paths.add(record_path)
+                    continue
+                retained_records.append(record)
+
+            if not removed:
+                return False
+
+            identifiers = [
+                item.get('checksum') or item.get('path') or item.get('filename')
+                for item in retained_records
+                if item.get('checksum') or item.get('path') or item.get('filename')
+            ]
+            total_unique = len(set(identifiers))
+
+            updates = {
+                'uploaded_files': retained_records,
+                'total_uploaded': total_unique
+            }
+
+            if removed_paths:
+                cache = dict(self._checksum_cache) if self._checksum_cache else {}
+                cache_modified = False
+                for path in removed_paths:
+                    if cache.pop(path, None) is not None:
+                        cache_modified = True
+                if cache_modified:
+                    updates['checksum_cache'] = cache
+
+            self._update_status_data(updates)
+            return True
 
     # Get list of files that need to be uploaded
     def collect_pending_uploads(self):
@@ -789,6 +890,33 @@ class PwnS3Upload(plugins.Plugin):
         normalized_path = (path or '').strip('/')
 
         if normalized_path in {'', None}:
+            feedback = None
+            if request.method == 'POST':
+                action = request.form.get('action') if request.form else None
+                if action == 'clear':
+                    identifier = (request.form.get('identifier') or '').strip()
+                    if identifier:
+                        if self.clear_uploaded_record(identifier):
+                            feedback = {
+                                'category': 'success',
+                                'message': f"Removed tracked entry for '{identifier}'."
+                            }
+                        else:
+                            feedback = {
+                                'category': 'error',
+                                'message': f"No tracked entry matched '{identifier}'."
+                            }
+                    else:
+                        feedback = {
+                            'category': 'error',
+                            'message': 'Unable to clear entry without an identifier.'
+                        }
+                else:
+                    feedback = {
+                        'category': 'error',
+                        'message': 'Unsupported action requested.'
+                    }
+
             self._refresh_status_data_from_disk()
             uploaded_records = self.get_uploaded_records()
 
@@ -818,10 +946,22 @@ class PwnS3Upload(plugins.Plugin):
                 except OSError:
                     status_mtime = None
 
-            status_data = dict(self._status_data)
-            status_json = json.dumps(status_data, indent=2, sort_keys=True)
             plugin_name = self.__module__.split('.')[-1]
-            raw_status_url = url_for('plugins', name=plugin_name, subpath='status.json')
+            page_url = url_for('plugins', name=plugin_name)
+            status_download_url = url_for('plugins', name=plugin_name, subpath='status.json')
+
+            display_records = []
+            for record in uploaded_records:
+                identifier = record.get('checksum') or record.get('path') or record.get('filename')
+                display_path = record.get('path') or record.get('filename') or 'n/a'
+                display_records.append({
+                    'display_path': display_path,
+                    'display_checksum': record.get('checksum') or 'n/a',
+                    'display_size': self._format_size(record.get('size')),
+                    'uploaded_at': record.get('uploaded_at') or 'n/a',
+                    'updated_at': record.get('updated_at') or record.get('uploaded_at') or 'n/a',
+                    'clear_identifier': identifier or '',
+                })
 
             return render_template_string(
                 WEB_STATUS_TEMPLATE,
@@ -829,17 +969,20 @@ class PwnS3Upload(plugins.Plugin):
                 status_exists=status_exists,
                 status_mtime=status_mtime,
                 status_summary=summary,
-                uploaded_records=uploaded_records,
-                status_json=status_json,
-                raw_status_url=raw_status_url
+                uploaded_records=display_records,
+                status_download_url=status_download_url,
+                page_url=page_url,
+                feedback=feedback
             )
 
         if normalized_path == 'status.json':
             self._refresh_status_data_from_disk()
-            return Response(
+            response = Response(
                 json.dumps(self._status_data, indent=2, sort_keys=True),
                 mimetype='application/json'
             )
+            response.headers['Content-Disposition'] = 'attachment; filename="s3_upload_status.json"'
+            return response
 
         abort(404)
     

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -18,6 +18,7 @@ import hashlib
 from threading import Lock
 from pwnagotchi.utils import StatusFile
 from json import JSONDecodeError
+from flask import abort, render_template_string, Response, url_for
 
 # Try to import boto3, install if not available
 try:
@@ -28,6 +29,79 @@ except ImportError:
     BOTO3_AVAILABLE = False
 
 TAG = "[S3 Plugin]"
+
+WEB_STATUS_TEMPLATE = """
+{% extends "base.html" %}
+{% set active_page = "plugins" %}
+{% block title %}S3 Upload Status{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col s12 m6">
+    <div class="card">
+      <div class="card-content">
+        <span class="card-title">Status Overview</span>
+        <p><strong>Status file:</strong> {{ status_path }}</p>
+        <p><strong>Exists:</strong> {{ 'Yes' if status_exists else 'No' }}</p>
+        <p><strong>Last updated:</strong> {{ status_mtime or 'Never' }}</p>
+        <p><strong>Total uploaded:</strong> {{ status_summary.total_uploaded }}</p>
+        <p><strong>Last upload:</strong> {{ status_summary.last_upload }}</p>
+      </div>
+    </div>
+  </div>
+  <div class="col s12 m6">
+    <div class="card">
+      <div class="card-content">
+        <span class="card-title">Pending Summary</span>
+        <p><strong>Total handshakes:</strong> {{ status_summary.total_handshakes }}</p>
+        <p><strong>Pending uploads:</strong> {{ status_summary.pending_count }}</p>
+        <p><strong>Uploaded entries tracked:</strong> {{ uploaded_records|length }}</p>
+      </div>
+      <div class="card-action">
+        <a href="{{ raw_status_url }}" target="_blank">View raw status JSON</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-content">
+    <span class="card-title">Tracked Uploads</span>
+    {% if uploaded_records %}
+    <table class="striped responsive-table">
+      <thead>
+        <tr>
+          <th>File</th>
+          <th>Checksum</th>
+          <th>Uploaded At</th>
+          <th>Updated At</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for record in uploaded_records %}
+        <tr>
+          <td>{{ record.path or record.filename }}</td>
+          <td><code>{{ record.checksum or 'n/a' }}</code></td>
+          <td>{{ record.uploaded_at or 'n/a' }}</td>
+          <td>{{ record.updated_at or record.uploaded_at or 'n/a' }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p>No upload records available.</p>
+    {% endif %}
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-content">
+    <span class="card-title">Raw Status Data</span>
+    <pre style="white-space: pre-wrap">{{ status_json }}</pre>
+  </div>
+</div>
+{% endblock %}
+"""
 
 class PwnS3Upload(plugins.Plugin):
     __author__ = 'gallis-local'
@@ -709,6 +783,65 @@ class PwnS3Upload(plugins.Plugin):
             'pending_files': pending_file_names,
             'last_upload': self.status_field_or('last_upload', 'Never')
         }
+
+    def on_webhook(self, path, request):
+        """Serve S3 upload status information within the web UI."""
+        normalized_path = (path or '').strip('/')
+
+        if normalized_path in {'', None}:
+            self._refresh_status_data_from_disk()
+            uploaded_records = self.get_uploaded_records()
+
+            try:
+                summary = self.get_upload_stats()
+            except Exception as exc:
+                self.LogDebug(f"Failed to refresh upload stats for web UI: {exc}")
+                summary = {
+                    'total_handshakes': 'n/a',
+                    'pending_count': 'n/a',
+                    'uploaded_count': len(uploaded_records),
+                    'uploaded_files': [],
+                    'pending_files': [],
+                    'last_upload': self.status_field_or('last_upload', 'Never'),
+                    'total_uploaded': self.status_field_or('total_uploaded', len(uploaded_records))
+                }
+
+            if 'total_uploaded' not in summary:
+                summary['total_uploaded'] = self.status_field_or('total_uploaded', len(uploaded_records))
+
+            status_exists = os.path.exists(self._status_path)
+            status_mtime = None
+            if status_exists:
+                try:
+                    mtime = os.path.getmtime(self._status_path)
+                    status_mtime = datetime.datetime.fromtimestamp(mtime).strftime("%Y-%m-%d %H:%M:%S")
+                except OSError:
+                    status_mtime = None
+
+            status_data = dict(self._status_data)
+            status_json = json.dumps(status_data, indent=2, sort_keys=True)
+            plugin_name = self.__module__.split('.')[-1]
+            raw_status_url = url_for('plugins', name=plugin_name, subpath='status.json')
+
+            return render_template_string(
+                WEB_STATUS_TEMPLATE,
+                status_path=self._status_path,
+                status_exists=status_exists,
+                status_mtime=status_mtime,
+                status_summary=summary,
+                uploaded_records=uploaded_records,
+                status_json=status_json,
+                raw_status_url=raw_status_url
+            )
+
+        if normalized_path == 'status.json':
+            self._refresh_status_data_from_disk()
+            return Response(
+                json.dumps(self._status_data, indent=2, sort_keys=True),
+                mimetype='application/json'
+            )
+
+        abort(404)
     
     # Get plugin configuration with defaults
     def get_plugin_config(self):

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -170,30 +170,35 @@ WEB_STATUS_TEMPLATE = """
   }
 
   .s3-status .inline-form .action-btn {
-    padding: 0;
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 999px;
+    padding: 0.45rem 0.95rem;
+    border-radius: 6px;
     border: none;
     background: #e53935;
     color: #fff;
     display: inline-flex;
     align-items: center;
-    justify-content: center;
+    gap: 0.4rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
     transition: background-color 150ms ease, box-shadow 150ms ease;
-    box-shadow: 0 2px 4px rgba(229, 57, 53, 0.3);
+    box-shadow: 0 2px 4px rgba(229, 57, 53, 0.25);
     cursor: pointer;
   }
 
   .s3-status .inline-form .action-btn:hover,
   .s3-status .inline-form .action-btn:focus {
     background: #c62828;
-    box-shadow: 0 4px 8px rgba(198, 40, 40, 0.35);
+    box-shadow: 0 4px 10px rgba(198, 40, 40, 0.35);
   }
 
   .s3-status .inline-form .action-btn i {
-    font-size: 1.25rem;
+    font-size: 1.15rem;
     color: inherit;
+  }
+
+  .s3-status .inline-form .action-btn .label {
+    font-size: 0.78rem;
   }
 
   .s3-status th.right-align,
@@ -202,64 +207,30 @@ WEB_STATUS_TEMPLATE = """
   }
 
   @media (max-width: 720px) {
+    .s3-status .status-meta {
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
     .s3-status .table-wrapper {
-      overflow: visible;
+      margin: 0 -1rem;
+      padding: 0 1rem;
+      overflow-x: auto;
     }
 
-    .s3-status table,
-    .s3-status thead,
-    .s3-status tbody,
-    .s3-status th,
-    .s3-status td,
-    .s3-status tr {
-      display: block;
+    .s3-status table {
+      min-width: 520px;
     }
 
-    .s3-status thead tr {
-      display: none;
+    .s3-status table td,
+    .s3-status table th {
+      padding: 0.75rem 0.85rem;
+      word-break: break-word;
     }
 
-    .s3-status tr {
-      margin-bottom: 1.2rem;
-      border: 1px solid rgba(176, 190, 197, 0.6);
-      border-radius: 6px;
-      padding: 0.75rem;
-    }
-
-    .s3-status td {
-      border: none;
-      position: relative;
-      padding-left: 45%;
-      min-height: 2.5rem;
-    }
-
-    .s3-status td::before {
-      content: attr(data-label);
-      position: absolute;
-      left: 0.9rem;
-      width: 42%;
-      font-weight: 600;
-      color: #546e7a;
-      text-transform: uppercase;
-      font-size: 0.7rem;
-      letter-spacing: 0.08em;
-    }
-
-    .s3-status td[data-label="Actions"] {
-      padding-left: 1rem;
-    }
-
-    .s3-status td[data-label="Actions"]::before {
-      display: none;
-    }
-
-    .s3-status .inline-form {
-      justify-content: flex-end;
-    }
-
-    .s3-status .inline-form button {
-      width: 2.5rem;
-      height: 2.5rem;
+    .s3-status table td .truncate {
+      max-width: 240px;
+      white-space: normal;
+      text-overflow: clip;
     }
   }
 </style>
@@ -347,6 +318,7 @@ WEB_STATUS_TEMPLATE = """
                   <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
                   <button type="submit" class="action-btn waves-effect waves-light" title="Remove this record" aria-label="Remove this record">
                     <i class="material-icons" aria-hidden="true">delete</i>
+                    <span class="label">Clear</span>
                   </button>
                 </form>
               </td>

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -135,23 +135,42 @@ WEB_STATUS_TEMPLATE = """
   .s3-status .download-link {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
-    color: #1a237e;
+    gap: 0.5rem;
+    color: #ffffff;
     text-decoration: none;
     font-weight: 600;
-    padding: 0.45rem 0.85rem;
-    border-radius: 8px;
-    transition: background 150ms ease, color 150ms ease;
+    font-size: 0.9rem;
+    padding: 0.75rem 1.25rem;
+    border-radius: 12px;
+    background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%);
+    box-shadow: 0 2px 8px rgba(25, 118, 210, 0.25);
+    transition: all 200ms ease;
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    user-select: none;
   }
 
-  .s3-status .download-link:hover,
+  .s3-status .download-link:hover {
+    background: linear-gradient(135deg, #1565c0 0%, #0d47a1 100%);
+    box-shadow: 0 4px 16px rgba(25, 118, 210, 0.35);
+    transform: translateY(-2px);
+  }
+
   .s3-status .download-link:focus {
-    background: rgba(26, 35, 126, 0.12);
-    color: #0d47a1;
+    outline: 2px solid #2196f3;
+    outline-offset: 2px;
+    background: linear-gradient(135deg, #1565c0 0%, #0d47a1 100%);
   }
 
-  .s3-status .download-link .material-icons {
+  .s3-status .download-link:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 8px rgba(25, 118, 210, 0.25);
+  }
+
+  .s3-status .download-link span[aria-hidden="true"] {
     font-size: 1.1rem;
+    margin-right: 0.1rem;
   }
 
   .s3-status .table-wrapper {
@@ -227,33 +246,61 @@ WEB_STATUS_TEMPLATE = """
   }
 
   .s3-status .inline-form .action-btn {
-    width: 42px;
-    height: 42px;
-    border-radius: 10px;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
     border: none;
-    background: #d32f2f;
-    color: #fff;
+    background: linear-gradient(135deg, #e53935 0%, #d32f2f 100%);
+    color: #ffffff;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    transition: all 200ms ease;
     cursor: pointer;
+    box-shadow: 0 2px 8px rgba(229, 57, 53, 0.25);
+    user-select: none;
+    position: relative;
+    overflow: hidden;
   }
 
-  .s3-status .inline-form .action-btn .material-icons {
-    font-size: 1.15rem;
+  .s3-status .inline-form .action-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.1);
+    opacity: 0;
+    transition: opacity 200ms ease;
+  }
+
+  .s3-status .inline-form .action-btn:hover::before {
+    opacity: 1;
+  }
+
+  .s3-status .inline-form .action-btn span[aria-hidden="true"] {
+    font-size: 1.2rem;
+    position: relative;
+    z-index: 1;
+    font-weight: bold;
   }
 
   .s3-status .inline-form .action-btn:hover,
   .s3-status .inline-form .action-btn:focus {
-    background: #b71c1c;
-    box-shadow: 0 4px 12px rgba(183, 28, 28, 0.35);
-    transform: translateY(-1px);
+    background: linear-gradient(135deg, #d32f2f 0%, #b71c1c 100%);
+    box-shadow: 0 4px 16px rgba(229, 57, 53, 0.4);
+    transform: translateY(-2px);
   }
 
-  .s3-status .inline-form .action-btn:focus-visible {
+  .s3-status .inline-form .action-btn:focus {
     outline: 2px solid #ffcdd2;
     outline-offset: 2px;
+  }
+
+  .s3-status .inline-form .action-btn:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 8px rgba(229, 57, 53, 0.25);
   }
 
   .s3-status th.right-align,
@@ -270,6 +317,33 @@ WEB_STATUS_TEMPLATE = """
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
     border: 0;
+  }
+
+  /* Button and link improvements */
+  .s3-status .btn-group {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  /* Improved focus management */
+  .s3-status button:focus-visible,
+  .s3-status a:focus-visible {
+    outline: 2px solid #2196f3;
+    outline-offset: 2px;
+  }
+
+  /* Loading state for buttons */
+  .s3-status .action-btn[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none !important;
+  }
+
+  .s3-status .action-btn[disabled]:hover {
+    transform: none !important;
+    box-shadow: 0 2px 8px rgba(229, 57, 53, 0.25) !important;
   }
 
   @media (max-width: 720px) {
@@ -305,6 +379,44 @@ WEB_STATUS_TEMPLATE = """
       max-width: 240px;
       white-space: normal;
       text-overflow: clip;
+    }
+
+    /* Mobile-friendly button adjustments */
+    .s3-status .download-link {
+      padding: 0.85rem 1rem;
+      font-size: 0.85rem;
+      min-height: 48px;
+    }
+
+    .s3-status .inline-form .action-btn {
+      width: 48px;
+      height: 48px;
+    }
+
+    .s3-status .btn-group {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.5rem;
+    }
+
+    .s3-status .download-link {
+      justify-content: center;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .s3-status .card-content {
+      padding: 1rem;
+    }
+
+    .s3-status .section-block {
+      padding: 1rem;
+      margin-top: 1rem;
+    }
+
+    .s3-status .status-meta {
+      grid-template-columns: 1fr;
+      gap: 0.75rem;
     }
   }
 </style>
@@ -361,10 +473,13 @@ WEB_STATUS_TEMPLATE = """
       <div class="section-block">
         <h3 class="section-heading">Status JSON</h3>
         <p class="section-text">Download the latest status snapshot to inspect the raw records.</p>
-        <a href="{{ status_download_url }}" class="download-link" download>
-          <i class="material-icons" aria-hidden="true">download</i>
-          <span>Download status JSON</span>
-        </a>
+        <div class="btn-group">
+          <a href="{{ status_download_url }}" class="download-link" download role="button" aria-describedby="download-description">
+            <span aria-hidden="true">⬇️</span>
+            <span>Download Status JSON</span>
+          </a>
+        </div>
+        <div id="download-description" class="sr-only">Download the complete status data as a JSON file for external analysis</div>
       </div>
     </div>
   </div>
@@ -400,9 +515,13 @@ WEB_STATUS_TEMPLATE = """
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <input type="hidden" name="action" value="clear">
                     <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
-                    <button type="submit" class="action-btn waves-effect" title="Clear this record">
-                      <i class="material-icons" aria-hidden="true">delete</i>
-                      <span class="sr-only">Clear this record</span>
+                    <button type="submit" 
+                            class="action-btn" 
+                            title="Clear this upload record" 
+                            aria-label="Clear upload record for {{ record.display_path }}"
+                            onclick="return confirm('Are you sure you want to clear this upload record? This action cannot be undone.');">
+                      <span aria-hidden="true">✕</span>
+                      <span class="sr-only">Clear record for {{ record.display_path }}</span>
                     </button>
                   </form>
                 </td>

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -48,6 +48,12 @@ WEB_STATUS_TEMPLATE = """
     margin-bottom: 2rem;
   }
 
+  .s3-status .card-title {
+    margin-bottom: 1rem;
+    font-weight: 600;
+    color: #263238;
+  }
+
   .s3-status .status-meta {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -55,31 +61,27 @@ WEB_STATUS_TEMPLATE = """
   }
 
   .s3-status .status-chip {
-    background: rgba(236, 239, 241, 0.8);
-    border-radius: 10px;
+    background: #eceff1;
+    border-radius: 12px;
     padding: 0.9rem 1.1rem;
     line-height: 1.45;
-    box-shadow: inset 0 0 0 1px rgba(120, 144, 156, 0.1);
+    box-shadow: inset 0 0 0 1px rgba(120, 144, 156, 0.18);
   }
 
   .s3-status .status-chip .label {
     text-transform: uppercase;
     font-size: 0.7rem;
-    letter-spacing: 0.1em;
-    color: #607d8b;
+    letter-spacing: 0.08em;
+    color: #546e7a;
     display: block;
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.35rem;
   }
 
   .s3-status .status-chip .value {
     font-weight: 600;
-    font-size: 1rem;
+    font-size: 0.95rem;
     word-break: break-word;
-    color: #263238;
-  }
-
-  .s3-status .card-title {
-    margin-bottom: 1rem;
+    color: #1c313a;
   }
 
   .s3-status .card-action {
@@ -87,29 +89,53 @@ WEB_STATUS_TEMPLATE = """
     justify-content: flex-end;
   }
 
+  .s3-status .card-action .btn {
+    background-color: #546e7a;
+  }
+
+  .s3-status .card-action .btn:hover {
+    background-color: #455a64;
+  }
+
   .s3-status .table-wrapper {
     margin-top: 1rem;
     overflow-x: auto;
-    border-radius: 10px;
-    border: 1px solid rgba(176, 190, 197, 0.4);
+    border-radius: 12px;
+    border: 1px solid rgba(176, 190, 197, 0.6);
   }
 
   .s3-status table {
     margin-bottom: 0;
     width: 100%;
-    min-width: 600px;
+    min-width: 640px;
+    border-collapse: collapse;
   }
 
   .s3-status table thead th {
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    font-size: 0.75rem;
-    color: #607d8b;
+    font-size: 0.72rem;
+    color: #455a64;
+    background-color: #eceff1;
+    border-bottom: 1px solid rgba(120, 144, 156, 0.3);
   }
 
   .s3-status table td,
   .s3-status table th {
-    padding: 0.9rem 1.1rem;
+    padding: 0.85rem 1rem;
+  }
+
+  .s3-status table tbody tr:nth-child(even) {
+    background-color: rgba(236, 239, 241, 0.35);
+  }
+
+  .s3-status table tbody tr:hover {
+    background-color: rgba(207, 216, 220, 0.5);
+  }
+
+  .s3-status table tbody td {
+    font-size: 0.9rem;
+    color: #37474f;
   }
 
   .s3-status td code,
@@ -117,6 +143,14 @@ WEB_STATUS_TEMPLATE = """
     word-break: break-all;
     font-family: "Roboto Mono", "Source Code Pro", monospace;
     font-size: 0.85rem;
+    color: #263238;
+  }
+
+  .s3-status td code {
+    background-color: rgba(207, 216, 220, 0.35);
+    padding: 0.2rem 0.35rem;
+    border-radius: 4px;
+    display: inline-block;
   }
 
   .s3-status .truncate {
@@ -125,20 +159,30 @@ WEB_STATUS_TEMPLATE = """
     max-width: 100%;
   }
 
-  .s3-status .table-wrapper .table-footer {
-    padding: 0.75rem 1rem;
-    font-size: 0.85rem;
-    color: #546e7a;
-  }
-
   .s3-status .inline-form {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
   }
 
   .s3-status .inline-form button {
-    padding: 0 0.75rem;
+    padding: 0;
+  }
+
+  .s3-status .inline-form button.icon-only {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .s3-status .inline-form button.icon-only i {
+    font-size: 1.25rem;
+  }
+
+  .s3-status th.right-align,
+  .s3-status td.right-align {
+    text-align: right;
   }
 
   @media (max-width: 720px) {
@@ -198,7 +242,8 @@ WEB_STATUS_TEMPLATE = """
     }
 
     .s3-status .inline-form button {
-      padding: 0 0.5rem;
+      width: 2.5rem;
+      height: 2.5rem;
     }
   }
 </style>
@@ -284,9 +329,8 @@ WEB_STATUS_TEMPLATE = """
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="action" value="clear">
                   <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
-                  <button type="submit" class="btn-flat waves-effect waves-red red-text text-darken-2" title="Remove this record">
-                    <i class="material-icons left" aria-hidden="true">backspace</i>
-                    Clear
+                  <button type="submit" class="btn-flat btn-small waves-effect waves-light red-text text-darken-2 icon-only" title="Remove this record" aria-label="Remove this record">
+                    <i class="material-icons" aria-hidden="true">delete</i>
                   </button>
                 </form>
               </td>

--- a/plugins/s3_upload.py
+++ b/plugins/s3_upload.py
@@ -44,53 +44,106 @@ WEB_STATUS_TEMPLATE = """
 {% block styles %}
 {{ super() }}
 <style>
+  .s3-status .card {
+    margin-bottom: 2rem;
+  }
+
   .s3-status .status-meta {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 1rem;
   }
 
   .s3-status .status-chip {
-    background: rgba(236, 239, 241, 0.6);
-    border-radius: 8px;
-    padding: 0.75rem 1rem;
-    line-height: 1.4;
+    background: rgba(236, 239, 241, 0.8);
+    border-radius: 10px;
+    padding: 0.9rem 1.1rem;
+    line-height: 1.45;
+    box-shadow: inset 0 0 0 1px rgba(120, 144, 156, 0.1);
   }
 
   .s3-status .status-chip .label {
     text-transform: uppercase;
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
     color: #607d8b;
     display: block;
-    margin-bottom: 0.35rem;
+    margin-bottom: 0.4rem;
   }
 
   .s3-status .status-chip .value {
     font-weight: 600;
+    font-size: 1rem;
     word-break: break-word;
+    color: #263238;
+  }
+
+  .s3-status .card-title {
+    margin-bottom: 1rem;
+  }
+
+  .s3-status .card-action {
+    display: flex;
+    justify-content: flex-end;
   }
 
   .s3-status .table-wrapper {
+    margin-top: 1rem;
     overflow-x: auto;
+    border-radius: 10px;
+    border: 1px solid rgba(176, 190, 197, 0.4);
   }
 
   .s3-status table {
-    min-width: 680px;
+    margin-bottom: 0;
+    width: 100%;
+    min-width: 600px;
   }
 
-  .s3-status td code {
+  .s3-status table thead th {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    color: #607d8b;
+  }
+
+  .s3-status table td,
+  .s3-status table th {
+    padding: 0.9rem 1.1rem;
+  }
+
+  .s3-status td code,
+  .s3-status td .mono {
     word-break: break-all;
+    font-family: "Roboto Mono", "Source Code Pro", monospace;
+    font-size: 0.85rem;
   }
 
   .s3-status .truncate {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     max-width: 100%;
+  }
+
+  .s3-status .table-wrapper .table-footer {
+    padding: 0.75rem 1rem;
+    font-size: 0.85rem;
+    color: #546e7a;
+  }
+
+  .s3-status .inline-form {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .s3-status .inline-form button {
+    padding: 0 0.75rem;
   }
 
   @media (max-width: 720px) {
     .s3-status .table-wrapper {
-      overflow-x: visible;
+      overflow: visible;
     }
 
     .s3-status table,
@@ -117,14 +170,14 @@ WEB_STATUS_TEMPLATE = """
       border: none;
       position: relative;
       padding-left: 45%;
-      min-height: 2rem;
+      min-height: 2.5rem;
     }
 
     .s3-status td::before {
       content: attr(data-label);
       position: absolute;
-      left: 0.75rem;
-      width: 40%;
+      left: 0.9rem;
+      width: 42%;
       font-weight: 600;
       color: #546e7a;
       text-transform: uppercase;
@@ -140,8 +193,12 @@ WEB_STATUS_TEMPLATE = """
       display: none;
     }
 
-    .s3-status form {
-      text-align: right;
+    .s3-status .inline-form {
+      justify-content: flex-end;
+    }
+
+    .s3-status .inline-form button {
+      padding: 0 0.5rem;
     }
   }
 </style>
@@ -203,7 +260,7 @@ WEB_STATUS_TEMPLATE = """
       <span class="card-title">Tracked Uploads</span>
       {% if uploaded_records %}
       <div class="table-wrapper">
-        <table class="striped highlight">
+        <table class="responsive-table striped highlight">
           <thead>
             <tr>
               <th scope="col">File</th>
@@ -217,7 +274,7 @@ WEB_STATUS_TEMPLATE = """
           <tbody>
             {% for record in uploaded_records %}
             <tr>
-              <td data-label="File"><span class="truncate">{{ record.display_path }}</span></td>
+              <td data-label="File"><span class="truncate mono">{{ record.display_path }}</span></td>
               <td data-label="Checksum"><code>{{ record.display_checksum }}</code></td>
               <td data-label="Size">{{ record.display_size }}</td>
               <td data-label="Uploaded">{{ record.uploaded_at }}</td>
@@ -227,7 +284,8 @@ WEB_STATUS_TEMPLATE = """
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="action" value="clear">
                   <input type="hidden" name="identifier" value="{{ record.clear_identifier }}">
-                  <button type="submit" class="btn-flat waves-effect red-text text-accent-4" title="Remove this record">
+                  <button type="submit" class="btn-flat waves-effect waves-red red-text text-darken-2" title="Remove this record">
+                    <i class="material-icons left" aria-hidden="true">backspace</i>
                     Clear
                   </button>
                 </form>


### PR DESCRIPTION
## Summary
- load and persist the S3 upload status cache so checksum comparisons survive plugin restarts
- refresh pending upload discovery using the persisted cache to skip already uploaded files while updating legacy records
- normalize and synchronize upload metadata in the status file to mirror files on disk

## Testing
- python -m compileall plugins/s3_upload.py

------
https://chatgpt.com/codex/tasks/task_e_68d8cb3f89e883258c7ea81b41c3ef73